### PR TITLE
allow the docker plugins folder to be configured from an env var

### DIFF
--- a/powerstripflocker.tac
+++ b/powerstripflocker.tac
@@ -1,5 +1,6 @@
 # Copyright ClusterHQ Inc. See LICENSE file for details.
 
+import os
 from twisted.web import server, resource
 from twisted.application import service, internet
 
@@ -20,5 +21,10 @@ def getAdapter():
 
 application = service.Application("Powerstrip Flocker Adapter")
 
-adapterServer = internet.UNIXServer("/usr/share/docker/plugins/flocker.sock", getAdapter())
+DOCKER_PLUGINS_FOLDER = os.environ.get("DOCKER_PLUGINS_FOLDER")
+
+if DOCKER_PLUGINS_FOLDER is None:
+    DOCKER_PLUGINS_FOLDER = "/usr/share/docker/plugins/flocker.sock"
+
+adapterServer = internet.UNIXServer(DOCKER_PLUGINS_FOLDER, getAdapter())
 adapterServer.setServiceParent(application)

--- a/powerstripflocker.tac
+++ b/powerstripflocker.tac
@@ -21,10 +21,8 @@ def getAdapter():
 
 application = service.Application("Powerstrip Flocker Adapter")
 
-DOCKER_PLUGINS_FOLDER = os.environ.get("DOCKER_PLUGINS_FOLDER")
-
-if DOCKER_PLUGINS_FOLDER is None:
-    DOCKER_PLUGINS_FOLDER = "/usr/share/docker/plugins/flocker.sock"
+DOCKER_PLUGINS_FOLDER = os.environ.get("DOCKER_PLUGINS_FOLDER",
+    "/usr/share/docker/plugins") + "/flocker.sock"
 
 adapterServer = internet.UNIXServer(DOCKER_PLUGINS_FOLDER, getAdapter())
 adapterServer.setServiceParent(application)


### PR DESCRIPTION
This allows the location of `/usr/share/docker/plugins` to be configured by the `DOCKER_PLUGINS_FOLDER` env var - useful for situations such as when the docker package is actually called docker.io
