### PR TITLE
Handle Flocker not returning a primary in dataset state

### DIFF
--- a/flockerdockerplugin/adapter.py
+++ b/flockerdockerplugin/adapter.py
@@ -109,6 +109,12 @@ class PathResource(resource.Resource):
             d.addCallback(get_path, dataset_id=dataset_id)
             return d
         d.addCallback(get_dataset)
+        def handle_failure(failure):
+            request.setHeader("Content-Type", "application/json")
+            request.write(json.dumps(dict(Mountpoint="", Err=str(failure))))
+            request.finish()
+            return failure
+        d.addErrback(handle_failure)
         return server.NOT_DONE_YET
 
 class UnmountResource(resource.Resource):
@@ -288,6 +294,12 @@ class MountResource(resource.Resource):
             d.addCallback(got_created_and_moved_datasets)
             return d
         d.addCallback(got_dataset_configuration)
+        def handle_failure(failure):
+            request.setHeader("Content-Type", "application/json")
+            request.write(json.dumps(dict(Mountpoint="", Err=str(failure))))
+            request.finish()
+            return failure
+        d.addErrback(handle_failure)
         d.addErrback(log.err, 'while processing configured datasets')
         return server.NOT_DONE_YET
 

--- a/flockerdockerplugin/adapter.py
+++ b/flockerdockerplugin/adapter.py
@@ -179,7 +179,8 @@ class MountResource(resource.Resource):
                         if dataset["dataset_id"] == dataset_id:
                             matching_datasets.append(dataset)
                     if len(matching_datasets) == 1:
-                        if matching_datasets[0]["primary"] == self.host_uuid:
+                        if ("primary" in matching_datasets[0] and
+                                matching_datasets[0]["primary"] == self.host_uuid):
                             return matching_datasets[0]
                     return False
                 d.addCallback(check_dataset_exists)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md") as readme:
 
     setup(
         name="FlockerDockerPlugin",
-        version="0.1",
+        version="0.2",
         author="ClusterHQ Labs",
         author_email="labs@clusterhq.com",
         url="https://clusterhq.com/",


### PR DESCRIPTION
- Sometimes Flocker doesn't return a primary immediately. Be lenient about that, assuming it's a transient issue. Should fix #14.

Bonus fix:
- Add generic error handling to catch exceptions from our own code and pass them back to Docker rather than just hanging the connection. Should fix #10.
