### PR TITLE
enable support for multiple socketpaths for docker 1.8 compatability

### DIFF
--- a/flockerdockerplugin/flockerdockerplugin.tac
+++ b/flockerdockerplugin/flockerdockerplugin.tac
@@ -1,11 +1,26 @@
 # Copyright ClusterHQ Inc. See LICENSE file for details.
 
+import os
 from twisted.web import server, resource
 from twisted.application import service, internet
 
 from flockerdockerplugin.adapter import (HandshakeResource, CreateResource,
     RemoveResource, PathResource, MountResource, UnmountResource)
 
+"""
+Docker 1.8 moved the plugins folder from 
+/usr/share/docker/plugins to
+/run/docker/plugins
+We will listen on both paths for backwards compat reasons
+"""
+socketPaths = [
+    "/usr/share/docker/plugins/flocker.sock",
+    "/run/docker/plugins/flocker.sock"
+]
+
+"""
+Create the handler that will deal with incoming requests
+"""
 def getAdapter():
     root = resource.Resource()
     root.putChild("Plugin.Activate", HandshakeResource())
@@ -18,7 +33,27 @@ def getAdapter():
     site = server.Site(root)
     return site
 
-application = service.Application("Flocker Docker Plugin")
+"""
+Create a UNIX socket on the given path and mount the 
+given adapter on the socket
+make the service parent of the server the given application
+"""
+def mountAdapter(path, adapter, app):
+    adapterServer = internet.UNIXServer(path, adapter)
+    adapterServer.setServiceParent(app)
 
-adapterServer = internet.UNIXServer("/usr/share/docker/plugins/flocker.sock", getAdapter())
-adapterServer.setServiceParent(application)
+"""
+The base application and adapter that will be mounted on each SocketPath
+"""
+application = service.Application("Flocker Docker Plugin")
+adapter = getAdapter()
+
+"""
+Loop over each socketPath - create the folder and then mount the adapter
+on the socket for that path
+"""
+for socketPath in socketPaths:
+    dirName = os.path.dirname(socketPath)
+    if not os.path.exists(dirName):
+        os.makedirs(dirName)
+    mountAdapter(socketPath, adapter, application)


### PR DESCRIPTION
upon booting - loop over a list of socketpaths and create the directory (if it does not exist)

use the same adapter and application and mount the adapter on each of the socket paths
